### PR TITLE
fix for wrong escape sequence

### DIFF
--- a/lib/InfluxDB/LineProtocol.pm
+++ b/lib/InfluxDB/LineProtocol.pm
@@ -77,7 +77,7 @@ sub _format_value {
     }
     else {
         # string actually, but this should be quoted differently?
-        $v =~ s/"/\\"/g;
+        $v =~ s/(["\\])/\\$1/g;
         $v = '"' . $v . '"';
     }
 
@@ -172,6 +172,7 @@ sub line2data {
     $line =~ s/\\ /ESCAPEDSPACE/g;
     $line =~ s/\\,/ESCAPEDCOMMA/g;
     $line =~ s/\\"/ESCAPEDDBLQUOTE/g;
+    $line =~ s/\\\\/ESCAPEDBACKSLASH/g;
 
     $line=~/^(.*?) (.*) (.*)$/;
     my ($key, $fields, $timestamp) = ( $1, $2, $3);
@@ -200,7 +201,9 @@ sub line2data {
         my ( $k, $v ) = split( /=/, $valset );
         $v =~ s/ESCAPEDSTRING_(\d+)/$strings[$1]/ge;
         $v =~ s/ESCAPEDDBLQUOTE/"/g;
+        $v =~ s/ESCAPEDBACKSLASH/\\/g;
         $v =~ s/^(-?\d+)i$/$1/;
+        $k =~ s/ESCAPEDBACKSLASH/\\\\/g;
         $values->{$k} = $v;
     }
 
@@ -269,7 +272,7 @@ sub _data2line_0_9_2 {
             $v !~ /^(?:F(?:ALSE)?|f(?:alse)?|T(?:RUE)?|t(?:rue)?)$/
         )
         {
-            $v =~ s/"/\\"/g;
+            $v =~ s/(["\\])/\\$1/g;
             $v = '"' . $v . '"';
         }
         push( @fields, $esc_k . '=' . $v );
@@ -286,6 +289,7 @@ sub _line2data_0_9_2 {
     $line =~ s/\\ /ESCAPEDSPACE/g;
     $line =~ s/\\,/ESCAPEDCOMMA/g;
     $line =~ s/\\"/ESCAPEDDBLQUOTE/g;
+    $line =~ s/\\\\/ESCAPEDBACKSLASH/g;
 
     $line=~/^(.*?) (.*) (.*)$/;
     my ($key, $fields, $timestamp) = ( $1, $2, $3);
@@ -314,6 +318,8 @@ sub _line2data_0_9_2 {
         my ( $k, $v ) = split( /=/, $valset );
         $v =~ s/ESCAPEDSTRING_(\d+)/$strings[$1]/ge;
         $v =~ s/ESCAPEDDBLQUOTE/"/g;
+        $v =~ s/ESCAPEDBACKSLASH/\\/g;
+        $k =~ s/ESCAPEDBACKSLASH/\\\\/g;
         $values->{$k} = $v;
     }
 

--- a/t/10_basic.t
+++ b/t/10_basic.t
@@ -2,6 +2,7 @@
 use strict;
 use warnings;
 use 5.012;
+use lib 'lib';
 use Test::Most;
 use InfluxDB::LineProtocol qw(data2line line2data);
 
@@ -228,7 +229,7 @@ my @tests = (
     [
         0,
         ['disk_free',{ value=> 442221834240, 'working directories'=>'C:\My Documents\Stuff for examples,C:\My Documents'}],
-        'disk_free value=442221834240i,working\ directories="C:\My Documents\Stuff for examples,C:\My Documents"',
+        'disk_free value=442221834240i,working\ directories="C:\\\\My Documents\\\\Stuff for examples,C:\\\\My Documents"',
         ['disk_free',{ value=> 442221834240, 'working directories'=>'C:\My Documents\Stuff for examples,C:\My Documents'}, undef],
     ],
     [

--- a/t/10_basic.t
+++ b/t/10_basic.t
@@ -191,6 +191,11 @@ my @tests = (
         'metric value="some \"value\""',
         ['metric', { value=>'some "value"' } , undef],
     ],
+    [   0,
+        [ 'metric', 'some \"value\"' ],
+        'metric value="some \\\\\"value\\\\\""',
+        [ 'metric', { value => 'some \"value\"' }, undef ],
+    ],
 
     # tag types
     # escape tags

--- a/t/11_precision.t
+++ b/t/11_precision.t
@@ -2,6 +2,7 @@
 use strict;
 use warnings;
 use 5.012;
+use lib 'lib';
 
 BEGIN {
     *CORE::GLOBAL::time = sub() {1437072205};

--- a/t/30_legacy_0_9_2.t
+++ b/t/30_legacy_0_9_2.t
@@ -2,6 +2,7 @@
 use strict;
 use warnings;
 use 5.012;
+use lib 'lib';
 use Test::Most;
 use InfluxDB::LineProtocol qw(v0.9.2 data2line line2data);
 


### PR DESCRIPTION
string values like `\"` are encoded as `\\"` which leads to an error when uploading to influxdb.
`\\\"` seems to work.

i added a unittest to reflect this situation and a fix as well

Thank you, Mario